### PR TITLE
modify installer service

### DIFF
--- a/templates/adminq-celeryconfig.py.j2
+++ b/templates/adminq-celeryconfig.py.j2
@@ -10,7 +10,7 @@ BROKER_USE_SSL = {
 }
 CELERY_SEND_EVENTS = True
 CELERY_TASK_RESULT_EXPIRES = None
-CELERY_ACCEPT_CONTENT = ['json, 'pickle']
+CELERY_ACCEPT_CONTENT = ['json', 'pickle']
 CELERY_RESULT_BACKEND = "{{ celery_adminq_result_backend }}"
 CELERY_MONGODB_BACKEND_SETTINGS = {
     "database": "{{ celery_adminq_mongodb }}",

--- a/templates/oulib-celery-workerq-installer.service.j2
+++ b/templates/oulib-celery-workerq-installer.service.j2
@@ -3,7 +3,7 @@ Description=OULibraries oulib-celery/workerq Service Installer
 
 [Service]
 WorkingDirectory={{ celery_workerq_dir }}
-ExecStart=/home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/python /home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/pip install -r requirements.txt --logfile {{ celery_workerq_log_dir }}/pip.log --loglevel WARNING
+ExecStart=/home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/python /home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/pip install -r requirements.txt --log {{ celery_workerq_log_dir }}/pip.log
 User={{ celery_workerq_user }}
 Type=oneshot
 

--- a/templates/oulib-celery-workerq-installer.service.j2
+++ b/templates/oulib-celery-workerq-installer.service.j2
@@ -3,7 +3,7 @@ Description=OULibraries oulib-celery/workerq Service Installer
 
 [Service]
 WorkingDirectory={{ celery_workerq_dir }}
-ExecStart={{ celery_workerq_dir }}/virtpy/bin/python {{ celery_workerq_dir }}/virtpy/bin/pip install -r requirements.txt --log {{ celery_workerq_log_dir }}/pip.log
+ExecStart=/home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/python /home/micromamba/{{ celery_workerq_user }}/envs/{{ mamba_env_name }}/bin/pip install -r requirements.txt --logfile {{ celery_workerq_log_dir }}/pip.log --loglevel WARNING
 User={{ celery_workerq_user }}
 Type=oneshot
 


### PR DESCRIPTION
Tyler noticed that the celery worker installer service unit file hadn't been updated to work with the new mamba setup. I've fixed the `ExecStart` directive, so it should attempt to install the dependencies using the binaries from the new mamba environment.